### PR TITLE
chore(ci): use correct github-action[bot] email address

### DIFF
--- a/.github/workflows/helm-repo-index-DEV.yaml
+++ b/.github/workflows/helm-repo-index-DEV.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Publish changes
         run: |
           git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add dev/index.yaml
           git commit -m "chore: update dev helm repo index, workflow run: $GITHUB_RUN_NUMBER"
           git push


### PR DESCRIPTION
If the commiter should be `github-actions` the email address should be as follows:

`41898282+github-actions[bot]@users.noreply.github.com`

see [community](https://github.com/orgs/community/discussions/26560).

Currently it will be displayed as _invalid-email-address_.

<img width="616" alt="image" src="https://github.com/mercedes-benz/eclipse-tractusx-charts/assets/16336640/e3303e69-82f8-4fd5-8834-e3259a9c7e14">
